### PR TITLE
Generalize type signature of `usingStateT`

### DIFF
--- a/core/src/Streamly/Internal/Data/Stream/Transformer.hs
+++ b/core/src/Streamly/Internal/Data/Stream/Transformer.hs
@@ -203,7 +203,7 @@ runStateT initial (Stream step state) = Stream step' (state, initial)
 usingStateT
     :: Monad m
     => m s
-    -> (Stream (StateT s m) a -> Stream (StateT s m) a)
+    -> (Stream (StateT s m) a -> Stream (StateT s m) b)
     -> Stream m a
-    -> Stream m a
+    -> Stream m b
 usingStateT s f = evalStateT s . f . liftInner


### PR DESCRIPTION
This PR changes two characters to generalize the type of `usingStateT`, making it possible to use it with functions that arbitrarily transform the items in a stream.

Here's an example motivating the need for this change. I rely on the below function to transform streams in a manner in which each item in a stream can be mapped to a new value that depends on an arbitrary state (which is typically built up from previous items in the stream):

```
import qualified Streamly.Data.Stream.Prelude  as S
import qualified Streamly.Internal.Data.Stream as S

stateMap
  :: Monad m => (a -> StateT s m (Maybe b)) -> s -> Stream m a -> Stream m b
stateMap f s = S.catMaybes . S.evalStateT (return s) . S.mapM f . S.liftInner
```

It should be possible to refactor this function as `stateMap f s = S.catMaybes . S.usingStateT (return s) (S.mapM f)`, but the present type of `usingStateT` overly constrains the type of the argument `f`.

(I'll also take this opportunity to ask: Is there is an established approach to doing the sort of thing I wrote stateMap for? I couldn't find any such pre-packaged functionality in the library.)